### PR TITLE
feat: Added Desk Page for Bench Manager

### DIFF
--- a/bench_manager/bench_manager/desk_page/bench_manager/bench_manager.json
+++ b/bench_manager/bench_manager/desk_page/bench_manager/bench_manager.json
@@ -1,0 +1,34 @@
+{
+ "cards": [
+  {
+   "hidden": 0,
+   "label": "Bench Setup",
+   "links": "[\n    {\n        \"description\": \"Frappe Apps\",\n        \"label\": \"App\",\n        \"name\": \"App\",\n        \"type\": \"doctype\"\n    },\n    {\n        \"description\": \"Bench Sites\",\n        \"label\": \"Site\",\n        \"name\": \"Site\",\n        \"type\": \"doctype\"\n    }\n]"
+  },
+  {
+   "hidden": 0,
+   "label": "Bench Management",
+   "links": "[\n    {\n        \"description\": \"Site Backup\",\n        \"label\": \"Site Backup\",\n        \"name\": \"Site Backup\",\n        \"type\": \"doctype\"\n    },\n    {\n        \"description\": \"Bench Manager Command\",\n        \"label\": \"Bench Manager Command\",\n        \"name\": \"Bench Manager Command\",\n        \"type\": \"doctype\"\n    },\n    {\n        \"description\": \"Bench Settings\",\n        \"label\": \"Bench Settings\",\n        \"name\": \"Bench Settings\",\n        \"type\": \"doctype\"\n    }\n]"
+  }
+ ],
+ "category": "Modules",
+ "charts": [],
+ "creation": "2020-11-09 16:11:39.761670",
+ "developer_mode_only": 0,
+ "disable_user_customization": 0,
+ "docstatus": 0,
+ "doctype": "Desk Page",
+ "extends_another_page": 0,
+ "hide_custom": 0,
+ "idx": 0,
+ "is_standard": 1,
+ "label": "Bench Manager",
+ "modified": "2020-11-09 16:12:55.805480",
+ "modified_by": "Administrator",
+ "module": "Bench Manager",
+ "name": "Bench Manager",
+ "owner": "Administrator",
+ "pin_to_bottom": 0,
+ "pin_to_top": 1,
+ "shortcuts": []
+}


### PR DESCRIPTION
Bench Manager with a compatible Desk Page for the v13 version of frappe

https://github.com/frappe/frappe_docs/pull/41

![Screenshot from 2020-11-09 16-36-21](https://user-images.githubusercontent.com/6005082/98604755-e9aa4680-22a9-11eb-993a-5054e4676fe6.png)